### PR TITLE
allow dots in strings

### DIFF
--- a/tm1637.py
+++ b/tm1637.py
@@ -173,3 +173,29 @@ class TM1637(object):
         for i in range(len(segments) + 5):
             self.write(data[0+i:4+i])
             sleep_ms(delay)
+
+
+class TM1637Decimal(TM1637):
+    """Library for quad 7-segment LED modules based on the TM1637 LED driver.
+
+    This class is meant to be used with decimal display modules (modules
+    that have a decimal point after each 7-segment LED).
+    """
+
+    def encode_string(self, string):
+        """Convert a string to LED segments.
+
+        Convert an up to 4 character length string containing 0-9, a-f,
+        space, dash and '.' to an array of segments, matching the length of
+        the source string.
+        """
+
+        segments = bytearray(len(string))
+        j = 0
+        for i in range(len(string)):
+            if string[i] == '.' and j > 0:
+                segments[j-1] |= 0b10000000
+                continue
+            segments[j] = self.encode_char(string[i])
+            j += 1
+        return segments


### PR DESCRIPTION
This add support for calling the `show` method with strings containing
dots, such as "8.8.8.8" or "1.234".