### PR TITLE
add license header

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 Mike Causer
+Copyright (c) 2016-2018 Mike Causer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tm1637.py
+++ b/tm1637.py
@@ -1,4 +1,8 @@
-# MicroPython TM1637 quad 7-segment LED display driver
+# MIT License - Copyright (c) 2016-2018 Mike Causer
+
+"""
+MicroPython TM1637 quad 7-segment LED display driver.
+"""
 
 from micropython import const
 from machine import Pin


### PR DESCRIPTION
because most people will copy/paste the .py module straight into their repository/codebase, I suggest adding a license header to the file. Also moved the description to a docstring.